### PR TITLE
Fix `use` Statements

### DIFF
--- a/src/V1/Asymmetric/Crypto.php
+++ b/src/V1/Asymmetric/Crypto.php
@@ -1,11 +1,11 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Asymmetric;
 
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\Util as CryptoUtil;
-use \ParagonIE\Halite\Contract;
-use \ParagonIE\Halite\Symmetric\Crypto as SymmetricCrypto;
-use \ParagonIE\Halite\Symmetric\EncryptionKey;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V1\Contract;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\Crypto as SymmetricCrypto;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\EncryptionKey;
 
 abstract class Crypto implements Contract\AsymmetricKeyCryptoInterface
 {

--- a/src/V1/Asymmetric/EncryptionPublicKey.php
+++ b/src/V1/Asymmetric/EncryptionPublicKey.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Asymmetric;
 
-use \ParagonIE\Halite\Util as CryptoUtil;
-use \ParagonIE\Halite\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 
 final class EncryptionPublicKey extends PublicKey
 {

--- a/src/V1/Asymmetric/EncryptionSecretKey.php
+++ b/src/V1/Asymmetric/EncryptionSecretKey.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Asymmetric;
 
-use \ParagonIE\Halite\Util as CryptoUtil;
-use \ParagonIE\Halite\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 
 final class EncryptionSecretKey extends SecretKey
 {

--- a/src/V1/Asymmetric/PublicKey.php
+++ b/src/V1/Asymmetric/PublicKey.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Asymmetric;
 
-use \ParagonIE\Halite\Contract;
-use \ParagonIE\Halite\Key;
+use \ParagonIE\HaliteLegacy\V1\Contract;
+use \ParagonIE\HaliteLegacy\V1\Key;
 
 class PublicKey extends Key implements Contract\KeyInterface
 {

--- a/src/V1/Asymmetric/SecretKey.php
+++ b/src/V1/Asymmetric/SecretKey.php
@@ -1,9 +1,9 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Asymmetric;
 
-use \ParagonIE\Halite\Contract;
-use \ParagonIE\Halite\Key;
-use \ParagonIE\Halite\Alerts\CannotPerformOperation;
+use \ParagonIE\HaliteLegacy\V1\Contract;
+use \ParagonIE\HaliteLegacy\V1\Key;
+use \ParagonIE\HaliteLegacy\V1\Alerts\CannotPerformOperation;
 
 class SecretKey extends Key implements Contract\KeyInterface
 {

--- a/src/V1/Asymmetric/SignaturePublicKey.php
+++ b/src/V1/Asymmetric/SignaturePublicKey.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Asymmetric;
 
-use \ParagonIE\Halite\Util as CryptoUtil;
-use \ParagonIE\Halite\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 
 final class SignaturePublicKey extends PublicKey
 {

--- a/src/V1/Asymmetric/SignatureSecretKey.php
+++ b/src/V1/Asymmetric/SignatureSecretKey.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Asymmetric;
 
-use \ParagonIE\Halite\Util as CryptoUtil;
-use \ParagonIE\Halite\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 
 final class SignatureSecretKey extends SecretKey
 {

--- a/src/V1/Config.php
+++ b/src/V1/Config.php
@@ -1,7 +1,7 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1;
 
-use ParagonIE\Halite\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 
 /**
  * Encapsulates the configuration for a specific version of Halite

--- a/src/V1/Contract/FileInterface.php
+++ b/src/V1/Contract/FileInterface.php
@@ -1,9 +1,9 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Contract;
 
-use \ParagonIE\Halite\Asymmetric\PublicKey;
-use \ParagonIE\Halite\Asymmetric\SecretKey;
-use \ParagonIE\Halite\Symmetric\SecretKey as SymmetricKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\PublicKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\SecretKey;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\SecretKey as SymmetricKey;
 
 /**
  * An interface for encrypting/decrypting files

--- a/src/V1/Contract/PasswordInterface.php
+++ b/src/V1/Contract/PasswordInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Contract;
 
-use \ParagonIE\Halite\Symmetric\EncryptionKey;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\EncryptionKey;
 
 /**
  * Hash then encrypt

--- a/src/V1/Contract/StreamInterface.php
+++ b/src/V1/Contract/StreamInterface.php
@@ -1,7 +1,7 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Contract;
 
-use ParagonIE\Halite\Alerts\FileAccessDenied;
+use ParagonIE\HaliteLegacy\V1\Alerts\FileAccessDenied;
 
 /**
  * 

--- a/src/V1/Contract/SymmetricKeyCryptoInterface.php
+++ b/src/V1/Contract/SymmetricKeyCryptoInterface.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Contract;
 
-use \ParagonIE\Halite\Symmetric\AuthenticationKey;
-use \ParagonIE\Halite\Symmetric\EncryptionKey;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\AuthenticationKey;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\EncryptionKey;
 
 /**
  * An interface fundamental to all cryptography implementations

--- a/src/V1/Cookie.php
+++ b/src/V1/Cookie.php
@@ -1,11 +1,11 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1;
 
-use \ParagonIE\Halite\Contract\KeyInterface;
-use \ParagonIE\Halite\Symmetric\EncryptionKey;
-use \ParagonIE\Halite\Symmetric\Crypto;
-use \ParagonIE\Halite\Alerts\InvalidType;
-use \ParagonIE\Halite\Alerts\InvalidMessage;
+use \ParagonIE\HaliteLegacy\V1\Contract\KeyInterface;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\EncryptionKey;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\Crypto;
+use \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType;
+use \ParagonIE\HaliteLegacy\V1\Alerts\InvalidMessage;
 
 final class Cookie 
 {
@@ -15,7 +15,7 @@ final class Cookie
     public function __construct(KeyInterface $key)
     {
         if (!($key instanceof EncryptionKey)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidKey(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidKey(
                 'Argument 1: Expected an instance of EncryptionKey'
             );
         }

--- a/src/V1/EncryptionKeyPair.php
+++ b/src/V1/EncryptionKeyPair.php
@@ -1,9 +1,9 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1;
 
-use ParagonIE\Halite\Asymmetric\EncryptionSecretKey;
-use ParagonIE\Halite\Asymmetric\EncryptionPublicKey;
-use ParagonIE\Halite\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V1\Asymmetric\EncryptionSecretKey;
+use ParagonIE\HaliteLegacy\V1\Asymmetric\EncryptionPublicKey;
+use ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 
 /**
  * Describes a pair of secret and public keys
@@ -155,7 +155,7 @@ final class EncryptionKeyPair extends KeyPair
      * @param string $password
      * @param string $salt
      * @param int $type
-     * @return array|\ParagonIE\Halite\KeyPair
+     * @return array|\ParagonIE\HaliteLegacy\V1\KeyPair
      * @throws CryptoException\InvalidFlags
      */
     public static function deriveFromPassword($password, $salt, $type = Key::CRYPTO_BOX)

--- a/src/V1/File.php
+++ b/src/V1/File.php
@@ -1,20 +1,20 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1;
 
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\Asymmetric\Crypto as AsymmetricCrypto;
-use \ParagonIE\Halite\Contract\KeyInterface;
-use \ParagonIE\Halite\Contract\StreamInterface;
-use \ParagonIE\Halite\Stream\MutableFile;
-use \ParagonIE\Halite\Stream\ReadOnlyFile;
-use \ParagonIE\Halite\Asymmetric\EncryptionSecretKey;
-use \ParagonIE\Halite\Asymmetric\EncryptionPublicKey;
-use \ParagonIE\Halite\Asymmetric\SignatureSecretKey;
-use \ParagonIE\Halite\Asymmetric\SignaturePublicKey;
-use \ParagonIE\Halite\Symmetric\AuthenticationKey;
-use \ParagonIE\Halite\Symmetric\EncryptionKey;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\Crypto as AsymmetricCrypto;
+use \ParagonIE\HaliteLegacy\V1\Contract\KeyInterface;
+use \ParagonIE\HaliteLegacy\V1\Contract\StreamInterface;
+use \ParagonIE\HaliteLegacy\V1\Stream\MutableFile;
+use \ParagonIE\HaliteLegacy\V1\Stream\ReadOnlyFile;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\EncryptionSecretKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\EncryptionPublicKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\SignatureSecretKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\SignaturePublicKey;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\AuthenticationKey;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\EncryptionKey;
 
-final class File implements \ParagonIE\Halite\Contract\FileInterface
+final class File implements \ParagonIE\HaliteLegacy\V1\Contract\FileInterface
 {
     /**
      * Lazy fallthrough method for checksumFile() and checksumResource()
@@ -37,7 +37,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
                 $raw
             );
         }
-        throw new \ParagonIE\Halite\Alerts\InvalidType(
+        throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
             'Argument 1: Expected a filename or resource'
         );
     }
@@ -67,7 +67,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
                 $key
             );
         }
-        throw new \ParagonIE\Halite\Alerts\InvalidType(
+        throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
             'Arguments 1 and 2 expect a filename or open file handle'
         );
     }
@@ -127,7 +127,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
                 $publickey
             );
         }
-        throw new \ParagonIE\Halite\Alerts\InvalidType(
+        throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
             'Arguments 1 and 2 expect a filename or open file handle'
         );
     }
@@ -162,7 +162,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
             );
             return $return;
         }
-        throw new \ParagonIE\Halite\Alerts\InvalidType(
+        throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
             'Arguments 1 and 2 expect a filename or open file handle'
         );
     }
@@ -192,7 +192,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
                 $raw_binary
             );
         }
-        throw new \ParagonIE\Halite\Alerts\InvalidType(
+        throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
             'Argument 1: Expected a filename or resource'
         );
     }
@@ -225,7 +225,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
                 $raw_binary
             );
         }
-        throw new \ParagonIE\Halite\Alerts\InvalidType(
+        throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
             'Argument 1: Expected a filename or resource'
         );
     }
@@ -283,7 +283,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
     ) {
         // Input validation
         if (!\is_resource($fileHandle)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidType(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
                 'Expected input handle to be a resource'
             );
         }
@@ -296,7 +296,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
     }
     /**
      * 
-     * @param \ParagonIE\Halite\Contract\StreamInterface $fileStream
+     * @param \ParagonIE\HaliteLegacy\V1\Contract\StreamInterface $fileStream
      * @param AuthenticationKey $key
      * @param bool $raw
      * @return string
@@ -312,7 +312,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
         $config = self::getConfig(Halite::HALITE_VERSION_FILE, 'checksum');
         if ($key) {
             if (!($key instanceof AuthenticationKey)) {
-                throw new \ParagonIE\Halite\Alerts\InvalidKey(
+                throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidKey(
                     'Argument 2: Expected an instance of AuthenticationKey'
                 );
             }
@@ -646,12 +646,12 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
     ) {
         // Input validation
         if (!\is_resource($input)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidType(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
                 'Expected input handle to be a resource'
             );
         }
         if (!\is_resource($output)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidType(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
                 'Expected output handle to be a resource'
             );
         }
@@ -683,7 +683,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
         $eph_public = '';
 
         if (!($key instanceof EncryptionKey)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidKey(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidKey(
                 'Argument 3: Expected an instance of EncryptionKey'
             );
         }
@@ -737,12 +737,12 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
     ) {
         // Input validation
         if (!\is_resource($input)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidType(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
                 'Expected input handle to be a resource'
             );
         }
         if (!\is_resource($output)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidType(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
                 'Expected output handle to be a resource'
             );
         }
@@ -768,7 +768,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
         KeyInterface $key
     ) {
         if (!($key instanceof EncryptionKey)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidKey(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidKey(
                 'Argument 3: Expected an instance of EncryptionKey'
             );
         }
@@ -832,12 +832,12 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
     ) {
         // Input validation
         if (!\is_resource($input)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidType(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
                 'Expected input handle to be a resource'
             );
         }
         if (!\is_resource($output)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidType(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
                 'Expected output handle to be a resource'
             );
         }
@@ -1086,7 +1086,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
         $raw_binary = false
     ) {
         if (!($secretkey instanceof SignatureSecretKey)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidKey(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidKey(
                 'Argument 1: Expected an instance of SignatureSecretKey'
             );
         }
@@ -1139,7 +1139,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
         $raw_binary = false
     ) {
         if (!($publickey instanceof SignaturePublicKey)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidKey(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidKey(
                 'Argument 2: Expected an instance of SignaturePublicKey'
             );
         }
@@ -1157,7 +1157,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
      * 
      * @param string $header
      * @param string $mode
-     * @return \ParagonIE\Halite\Config
+     * @return \ParagonIE\HaliteLegacy\V1\Config
      * @throws CryptoException\InvalidMessage
      * @throws \Error
      */
@@ -1271,14 +1271,14 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
     /**
      * Split a key using HKDF
      * 
-     * @param \ParagonIE\Halite\Contract\KeyInterface $master
+     * @param \ParagonIE\HaliteLegacy\V1\Contract\KeyInterface $master
      * @param string $salt
      * @param Config $config
      * @return array
      * @throws \TypeError
      */
     protected static function splitKeys(
-        \ParagonIE\Halite\Contract\KeyInterface $master,
+        \ParagonIE\HaliteLegacy\V1\Contract\KeyInterface $master,
         $salt = null,
         Config $config = null
     ) {
@@ -1327,7 +1327,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
         Config $config
     ) {
         if (!($encKey instanceof EncryptionKey)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidKey(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidKey(
                 'Argument 3: Expected an instance of EncryptionKey'
             );
         }
@@ -1387,7 +1387,7 @@ final class File implements \ParagonIE\Halite\Contract\FileInterface
         array &$chunk_macs
     ) {
         if (!($encKey instanceof EncryptionKey)) {
-            throw new \ParagonIE\Halite\Alerts\InvalidKey(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidKey(
                 'Argument 3: Expected an instance of EncryptionKey'
             );
         }

--- a/src/V1/Key.php
+++ b/src/V1/Key.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1;
 
-use ParagonIE\Halite\Alerts as CryptoException;
-use ParagonIE\Halite\Contract;
+use ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V1\Contract;
 
 /**
  * Symmetric Key Crypography uses one secret key, while Asymmetric Key Cryptography

--- a/src/V1/KeyFactory.php
+++ b/src/V1/KeyFactory.php
@@ -1,16 +1,16 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1;
 
-use ParagonIE\Halite\Alerts\CannotPerformOperation;
-use \ParagonIE\Halite\Asymmetric\EncryptionPublicKey;
-use \ParagonIE\Halite\Asymmetric\EncryptionSecretKey;
-use \ParagonIE\Halite\Asymmetric\SignaturePublicKey;
-use \ParagonIE\Halite\Asymmetric\SignatureSecretKey;
-use \ParagonIE\Halite\Symmetric\AuthenticationKey;
-use \ParagonIE\Halite\Symmetric\EncryptionKey;
-use \ParagonIE\Halite\Halite;
-use \ParagonIE\Halite\Key;
-use \ParagonIE\Halite\KeyPair;
+use ParagonIE\HaliteLegacy\V1\Alerts\CannotPerformOperation;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\EncryptionPublicKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\EncryptionSecretKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\SignaturePublicKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\SignatureSecretKey;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\AuthenticationKey;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\EncryptionKey;
+use \ParagonIE\HaliteLegacy\V1\Halite;
+use \ParagonIE\HaliteLegacy\V1\Key;
+use \ParagonIE\HaliteLegacy\V1\KeyPair;
 
 /**
  * Class for generating specific key types

--- a/src/V1/KeyPair.php
+++ b/src/V1/KeyPair.php
@@ -1,11 +1,11 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1;
 
-use \ParagonIE\Halite\Asymmetric\EncryptionSecretKey;
-use \ParagonIE\Halite\Asymmetric\EncryptionPublicKey;
-use \ParagonIE\Halite\Asymmetric\SignatureSecretKey;
-use \ParagonIE\Halite\Asymmetric\SignaturePublicKey;
-use \ParagonIE\Halite\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\EncryptionSecretKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\EncryptionPublicKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\SignatureSecretKey;
+use \ParagonIE\HaliteLegacy\V1\Asymmetric\SignaturePublicKey;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 use Psr\Log\InvalidArgumentException;
 
 /**

--- a/src/V1/Password.php
+++ b/src/V1/Password.php
@@ -1,16 +1,16 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1;
 
-use \ParagonIE\Halite\Alerts\InvalidKey;
-use \ParagonIE\Halite\Alerts\InvalidType;
-use \ParagonIE\Halite\Contract\KeyInterface;
-use \ParagonIE\Halite\Symmetric\Crypto;
-use \ParagonIE\Halite\Symmetric\EncryptionKey;
+use \ParagonIE\HaliteLegacy\V1\Alerts\InvalidKey;
+use \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType;
+use \ParagonIE\HaliteLegacy\V1\Contract\KeyInterface;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\Crypto;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\EncryptionKey;
 
 /**
  * Secure password storage and secure password verification
  */
-abstract class Password implements \ParagonIE\Halite\Contract\PasswordInterface
+abstract class Password implements \ParagonIE\HaliteLegacy\V1\Contract\PasswordInterface
 {
     /**
      * Hash then encrypt a password

--- a/src/V1/SignatureKeyPair.php
+++ b/src/V1/SignatureKeyPair.php
@@ -1,9 +1,9 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1;
 
-use ParagonIE\Halite\Asymmetric\SignatureSecretKey;
-use ParagonIE\Halite\Asymmetric\SignaturePublicKey;
-use ParagonIE\Halite\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V1\Asymmetric\SignatureSecretKey;
+use ParagonIE\HaliteLegacy\V1\Asymmetric\SignaturePublicKey;
+use ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 
 /**
  * Describes a pair of secret and public keys

--- a/src/V1/Stream/MutableFile.php
+++ b/src/V1/Stream/MutableFile.php
@@ -1,9 +1,9 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Stream;
 
-use \ParagonIE\Halite\Contract\StreamInterface;
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\Util;
+use \ParagonIE\HaliteLegacy\V1\Contract\StreamInterface;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Util;
 
 /**
  * Contrast with ReadOnlyFile: does not prevent race conditions by itself
@@ -43,7 +43,7 @@ class MutableFile implements StreamInterface
             $this->pos = \ftell($this->fp);
             $this->stat = \fstat($this->fp);
         } else {
-            throw new \ParagonIE\Halite\Alerts\InvalidType(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
                 'Argument 1: Expected a filename or resource'
             );
         }

--- a/src/V1/Stream/ReadOnlyFile.php
+++ b/src/V1/Stream/ReadOnlyFile.php
@@ -1,9 +1,9 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Stream;
 
-use \ParagonIE\Halite\Contract\StreamInterface;
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\Util;
+use \ParagonIE\HaliteLegacy\V1\Contract\StreamInterface;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Util;
 
 class ReadOnlyFile implements StreamInterface
 {
@@ -44,7 +44,7 @@ class ReadOnlyFile implements StreamInterface
             $this->pos = \ftell($this->fp);
             $this->stat = \fstat($this->fp);
         } else {
-            throw new \ParagonIE\Halite\Alerts\InvalidType(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidType(
                 'Argument 1: Expected a filename or resource'
             );
         }

--- a/src/V1/Symmetric/AuthenticationKey.php
+++ b/src/V1/Symmetric/AuthenticationKey.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Symmetric;
 
-use \ParagonIE\Halite\Util as CryptoUtil;
-use \ParagonIE\Halite\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 
 final class AuthenticationKey extends SecretKey
 {

--- a/src/V1/Symmetric/Config.php
+++ b/src/V1/Symmetric/Config.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Symmetric;
 
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\Config as BaseConfig;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Config as BaseConfig;
 
 final class Config extends BaseConfig
 {
@@ -11,7 +11,7 @@ final class Config extends BaseConfig
      * 
      * @param string $header
      * @param string $mode
-     * @return \ParagonIE\Halite\Config
+     * @return \ParagonIE\HaliteLegacy\V1\Config
      * @throws CryptoException\InvalidMessage
      */
     public static function getConfig($header, $mode = 'encrypt')

--- a/src/V1/Symmetric/Crypto.php
+++ b/src/V1/Symmetric/Crypto.php
@@ -1,12 +1,12 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Symmetric;
 
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\Contract;
-use \ParagonIE\Halite\Util as CryptoUtil;
-use \ParagonIE\Halite\Halite;
-use \ParagonIE\Halite\Config;
-use \ParagonIE\Halite\Symmetric\Config as SymmetricConfig;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Contract;
+use \ParagonIE\HaliteLegacy\V1\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V1\Halite;
+use \ParagonIE\HaliteLegacy\V1\Config;
+use \ParagonIE\HaliteLegacy\V1\Symmetric\Config as SymmetricConfig;
 
 abstract class Crypto implements Contract\SymmetricKeyCryptoInterface
 {

--- a/src/V1/Symmetric/EncryptionKey.php
+++ b/src/V1/Symmetric/EncryptionKey.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Symmetric;
 
-use \ParagonIE\Halite\Util as CryptoUtil;
-use \ParagonIE\Halite\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V1\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;
 
 final class EncryptionKey extends SecretKey
 {

--- a/src/V1/Symmetric/SecretKey.php
+++ b/src/V1/Symmetric/SecretKey.php
@@ -1,8 +1,8 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V1\Symmetric;
 
-use \ParagonIE\Halite\Contract;
-use \ParagonIE\Halite\Key;
+use \ParagonIE\HaliteLegacy\V1\Contract;
+use \ParagonIE\HaliteLegacy\V1\Key;
 
 class SecretKey extends Key implements Contract\KeyInterface
 {

--- a/src/V1/Util.php
+++ b/src/V1/Util.php
@@ -18,8 +18,8 @@ abstract class Util
      * @param string $info What sort of key are we deriving?
      * @param string $salt
      * @return string
-     * @throws \ParagonIE\Halite\Alerts\InvalidDigestLength
-     * @throws \ParagonIE\Halite\Alerts\CannotPerformOperation
+     * @throws \ParagonIE\HaliteLegacy\V1\Alerts\InvalidDigestLength
+     * @throws \ParagonIE\HaliteLegacy\V1\Alerts\CannotPerformOperation
      */
     public static function hkdfBlake2b($ikm, $length, $info = '', $salt = null)
     {
@@ -29,7 +29,7 @@ abstract class Util
             || $length < 0
             || $length > 255 * \Sodium\CRYPTO_GENERICHASH_KEYBYTES
         ) {
-            throw new \ParagonIE\Halite\Alerts\InvalidDigestLength(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\InvalidDigestLength(
                 'Bad HKDF Digest Length'
             );
         }
@@ -47,7 +47,7 @@ abstract class Util
         // HKDF-Expand:
         // This check is useless, but it serves as a reminder to the spec.
         if (self::safeStrlen($prk) < \Sodium\CRYPTO_GENERICHASH_KEYBYTES) {
-            throw new \ParagonIE\Halite\Alerts\CannotPerformOperation(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\CannotPerformOperation(
                 'An unknown error has occurred'
             );
         }
@@ -67,7 +67,7 @@ abstract class Util
         // ORM = first L octets of T
         $orm = self::safeSubstr($t, 0, $length);
         if ($orm === false) {
-            throw new \ParagonIE\Halite\Alerts\CannotPerformOperation(
+            throw new \ParagonIE\HaliteLegacy\V1\Alerts\CannotPerformOperation(
                 'An unknown error has occurred'
             );
         }
@@ -82,7 +82,7 @@ abstract class Util
      * @staticvar boolean $exists
      * @param string $str
      * @return int
-     * @throws \ParagonIE\Halite\Alerts\CannotPerformOperation
+     * @throws \ParagonIE\HaliteLegacy\V1\Alerts\CannotPerformOperation
      */
     public static function safeStrlen($str)
     {

--- a/src/V2/Asymmetric/Crypto.php
+++ b/src/V2/Asymmetric/Crypto.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Asymmetric;
 
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\{
+use \ParagonIE\HaliteLegacy\V2\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V2\{
     Util as CryptoUtil,
     Key,
     Symmetric\Crypto as SymmetricCrypto,
@@ -15,7 +15,7 @@ use \ParagonIE\Halite\{
  *
  * Handles all public key cryptography
  *
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V2\Asymmetric
  */
 abstract class Crypto
 {

--- a/src/V2/Asymmetric/EncryptionPublicKey.php
+++ b/src/V2/Asymmetric/EncryptionPublicKey.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Asymmetric;
 
-use \ParagonIE\Halite\Alerts\InvalidKey;
-use \ParagonIE\Halite\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V2\Alerts\InvalidKey;
+use \ParagonIE\HaliteLegacy\V2\Util as CryptoUtil;
 
 /**
  * Class EncryptionPublicKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V2\Asymmetric
  */
 final class EncryptionPublicKey extends PublicKey
 {

--- a/src/V2/Asymmetric/EncryptionSecretKey.php
+++ b/src/V2/Asymmetric/EncryptionSecretKey.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Asymmetric;
 
-use \ParagonIE\Halite\Alerts\InvalidKey;
-use \ParagonIE\Halite\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V2\Alerts\InvalidKey;
+use \ParagonIE\HaliteLegacy\V2\Util as CryptoUtil;
 
 /**
  * Class EncryptionSecretKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V2\Asymmetric
  */
 final class EncryptionSecretKey extends SecretKey
 {

--- a/src/V2/Asymmetric/PublicKey.php
+++ b/src/V2/Asymmetric/PublicKey.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Asymmetric;
 
-use \ParagonIE\Halite\Contract;
-use \ParagonIE\Halite\Key;
+use \ParagonIE\HaliteLegacy\V2\Contract;
+use \ParagonIE\HaliteLegacy\V2\Key;
 
 /**
  * Class PublicKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V2\Asymmetric
  */
 class PublicKey extends Key
 {

--- a/src/V2/Asymmetric/SecretKey.php
+++ b/src/V2/Asymmetric/SecretKey.php
@@ -1,13 +1,13 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V2\Asymmetric;
 
-use \ParagonIE\Halite\Contract;
-use \ParagonIE\Halite\Key;
-use \ParagonIE\Halite\Alerts\CannotPerformOperation;
+use \ParagonIE\HaliteLegacy\V2\Contract;
+use \ParagonIE\HaliteLegacy\V2\Key;
+use \ParagonIE\HaliteLegacy\V2\Alerts\CannotPerformOperation;
 
 /**
  * Class SecretKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V2\Asymmetric
  */
 class SecretKey extends Key
 {

--- a/src/V2/Asymmetric/SignaturePublicKey.php
+++ b/src/V2/Asymmetric/SignaturePublicKey.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Asymmetric;
 
-use \ParagonIE\Halite\Alerts\InvalidKey;
-use \ParagonIE\Halite\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V2\Alerts\InvalidKey;
+use \ParagonIE\HaliteLegacy\V2\Util as CryptoUtil;
 
 /**
  * Class SignaturePublicKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V2\Asymmetric
  */
 final class SignaturePublicKey extends PublicKey
 {

--- a/src/V2/Asymmetric/SignatureSecretKey.php
+++ b/src/V2/Asymmetric/SignatureSecretKey.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Asymmetric;
 
-use \ParagonIE\Halite\Alerts\InvalidKey;
-use \ParagonIE\Halite\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V2\Alerts\InvalidKey;
+use \ParagonIE\HaliteLegacy\V2\Util as CryptoUtil;
 
 /**
  * Class SignatureSecretKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V2\Asymmetric
  */
 final class SignatureSecretKey extends SecretKey
 {

--- a/src/V2/Config.php
+++ b/src/V2/Config.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use ParagonIE\Halite\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V2\Alerts as CryptoException;
 
 /**
  * Class Config

--- a/src/V2/Contract/StreamInterface.php
+++ b/src/V2/Contract/StreamInterface.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Contract;
 
-use \ParagonIE\Halite\Alerts\{
+use \ParagonIE\HaliteLegacy\V2\Alerts\{
     CannotPerformOperation,
     FileAccessDenied
 };
@@ -12,7 +12,7 @@ use \ParagonIE\Halite\Alerts\{
  *
  * A stream used by Halite, internally.
  *
- * @package ParagonIE\Halite\Contract
+ * @package ParagonIE\HaliteLegacy\V2\Contract
  */
 interface StreamInterface
 {

--- a/src/V2/Cookie.php
+++ b/src/V2/Cookie.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use \ParagonIE\Halite\{
+use \ParagonIE\HaliteLegacy\V2\{
     Alerts\InvalidMessage,
     Symmetric\EncryptionKey,
     Symmetric\Crypto

--- a/src/V2/EncryptionKeyPair.php
+++ b/src/V2/EncryptionKeyPair.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V2\{
     Alerts as CryptoException,
     Asymmetric\EncryptionPublicKey,
     Asymmetric\EncryptionSecretKey

--- a/src/V2/File.php
+++ b/src/V2/File.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\{
+use \ParagonIE\HaliteLegacy\V2\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V2\{
     Asymmetric\Crypto as AsymmetricCrypto,
     Asymmetric\EncryptionPublicKey,
     Asymmetric\EncryptionSecretKey,

--- a/src/V2/Key.php
+++ b/src/V2/Key.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use ParagonIE\Halite\Alerts as CryptoException;
-use ParagonIE\Halite\Contract;
+use ParagonIE\HaliteLegacy\V2\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V2\Contract;
 
 /**
  * Class Key

--- a/src/V2/KeyFactory.php
+++ b/src/V2/KeyFactory.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\{
+use \ParagonIE\HaliteLegacy\V2\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V2\{
     Asymmetric\EncryptionPublicKey,
     Asymmetric\EncryptionSecretKey,
     Asymmetric\SignaturePublicKey,
@@ -58,7 +58,7 @@ abstract class KeyFactory
      * Generate a key pair for public key encryption
      * 
      * @param string &$secret_key
-     * @return \ParagonIE\Halite\EncryptionKeyPair
+     * @return \ParagonIE\HaliteLegacy\V2\EncryptionKeyPair
      */
     public static function generateEncryptionKeyPair(string &$secret_key = ''): EncryptionKeyPair
     {

--- a/src/V2/KeyPair.php
+++ b/src/V2/KeyPair.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\Asymmetric\{
+use \ParagonIE\HaliteLegacy\V2\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V2\Asymmetric\{
     PublicKey,
     SecretKey
 };

--- a/src/V2/Password.php
+++ b/src/V2/Password.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use \ParagonIE\Halite\{
+use \ParagonIE\HaliteLegacy\V2\{
     Alerts\InvalidMessage,
     Symmetric\Config as SymmetricConfig,
     Symmetric\Crypto,

--- a/src/V2/SignatureKeyPair.php
+++ b/src/V2/SignatureKeyPair.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V2\{
     Alerts as CryptoException,
     Asymmetric\SignaturePublicKey,
     Asymmetric\SignatureSecretKey

--- a/src/V2/Stream/MutableFile.php
+++ b/src/V2/Stream/MutableFile.php
@@ -2,9 +2,9 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Stream;
 
-use \ParagonIE\Halite\Contract\StreamInterface;
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V2\Contract\StreamInterface;
+use \ParagonIE\HaliteLegacy\V2\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V2\Util as CryptoUtil;
 
 /**
  * Contrast with ReadOnlyFile: does not prevent race conditions by itself

--- a/src/V2/Stream/ReadOnlyFile.php
+++ b/src/V2/Stream/ReadOnlyFile.php
@@ -2,10 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Stream;
 
-use \ParagonIE\Halite\Contract\StreamInterface;
-use \ParagonIE\Halite\Alerts as CryptoException;
-use \ParagonIE\Halite\Key;
-use \ParagonIE\Halite\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V2\Contract\StreamInterface;
+use \ParagonIE\HaliteLegacy\V2\Alerts as CryptoException;
+use \ParagonIE\HaliteLegacy\V2\Key;
+use \ParagonIE\HaliteLegacy\V2\Util as CryptoUtil;
 
 class ReadOnlyFile implements StreamInterface
 {

--- a/src/V2/Structure/MerkleTree.php
+++ b/src/V2/Structure/MerkleTree.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Structure;
 
-use \ParagonIE\Halite\Util;
-use \ParagonIE\Halite\Alerts\InvalidDigestLength;
+use \ParagonIE\HaliteLegacy\V2\Util;
+use \ParagonIE\HaliteLegacy\V2\Alerts\InvalidDigestLength;
 
 /**
  * Class MerkleTree
@@ -11,7 +11,7 @@ use \ParagonIE\Halite\Alerts\InvalidDigestLength;
  * An implementation of a Merkle hash tree, built on the BLAKE2b hash function
  * (provided by libsodium)
  *
- * @package ParagonIE\Halite\Structure
+ * @package ParagonIE\HaliteLegacy\V2\Structure
  */
 class MerkleTree
 {

--- a/src/V2/Structure/Node.php
+++ b/src/V2/Structure/Node.php
@@ -2,11 +2,11 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Structure;
 
-use \ParagonIE\Halite\Util;
+use \ParagonIE\HaliteLegacy\V2\Util;
 
 /**
  * Class Node
- * @package ParagonIE\Halite\Structure
+ * @package ParagonIE\HaliteLegacy\V2\Structure
  */
 class Node
 {

--- a/src/V2/Symmetric/AuthenticationKey.php
+++ b/src/V2/Symmetric/AuthenticationKey.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Symmetric;
 
-use \ParagonIE\Halite\Alerts\InvalidKey;
-use \ParagonIE\Halite\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V2\Alerts\InvalidKey;
+use \ParagonIE\HaliteLegacy\V2\Util as CryptoUtil;
 
 /**
  * Class AuthenticationKey
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V2\Symmetric
  */
 final class AuthenticationKey extends SecretKey
 {

--- a/src/V2/Symmetric/Config.php
+++ b/src/V2/Symmetric/Config.php
@@ -2,14 +2,14 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Symmetric;
 
-use \ParagonIE\Halite\{
+use \ParagonIE\HaliteLegacy\V2\{
     Alerts as CryptoException,
     Config as BaseConfig
 };
 
 /**
  * Class Config
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V2\Symmetric
  */
 final class Config extends BaseConfig
 {

--- a/src/V2/Symmetric/Crypto.php
+++ b/src/V2/Symmetric/Crypto.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Symmetric;
 
-use \ParagonIE\Halite\{
+use \ParagonIE\HaliteLegacy\V2\{
     Alerts as CryptoException,
     Config,
     Halite,
@@ -15,7 +15,7 @@ use \ParagonIE\Halite\{
  *
  * Encapsulates symmetric-key cryptography
  *
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V2\Symmetric
  */
 abstract class Crypto
 {

--- a/src/V2/Symmetric/EncryptionKey.php
+++ b/src/V2/Symmetric/EncryptionKey.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Symmetric;
 
-use \ParagonIE\Halite\Alerts\InvalidKey;
-use \ParagonIE\Halite\Util as CryptoUtil;
+use \ParagonIE\HaliteLegacy\V2\Alerts\InvalidKey;
+use \ParagonIE\HaliteLegacy\V2\Util as CryptoUtil;
 
 /**
  * Class EncryptionKey
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V2\Symmetric
  */
 final class EncryptionKey extends SecretKey
 {

--- a/src/V2/Symmetric/SecretKey.php
+++ b/src/V2/Symmetric/SecretKey.php
@@ -2,11 +2,11 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2\Symmetric;
 
-use \ParagonIE\Halite\Key;
+use \ParagonIE\HaliteLegacy\V2\Key;
 
 /**
  * Class SecretKey
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V2\Symmetric
  */
 class SecretKey extends Key
 {

--- a/src/V2/Util.php
+++ b/src/V2/Util.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V2;
 
-use \ParagonIE\Halite\Alerts\{
+use \ParagonIE\HaliteLegacy\V2\Alerts\{
     CannotPerformOperation,
     InvalidDigestLength,
     InvalidType

--- a/src/V3/Asymmetric/Crypto.php
+++ b/src/V3/Asymmetric/Crypto.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Asymmetric;
 
-use ParagonIE\Halite\Alerts\{
+use ParagonIE\HaliteLegacy\V3\Alerts\{
     CannotPerformOperation,
     InvalidKey,
     InvalidMessage,
     InvalidSignature
 };
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V3\{
     Util as CryptoUtil,
     Halite,
     HiddenString,
@@ -27,7 +27,7 @@ use ParagonIE\Halite\{
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V3\Asymmetric
  */
 final class Crypto
 {

--- a/src/V3/Asymmetric/EncryptionPublicKey.php
+++ b/src/V3/Asymmetric/EncryptionPublicKey.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Asymmetric;
 
-use ParagonIE\Halite\Alerts\InvalidKey;
-use ParagonIE\Halite\HiddenString;
-use ParagonIE\Halite\Util as CryptoUtil;
+use ParagonIE\HaliteLegacy\V3\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V3\HiddenString;
+use ParagonIE\HaliteLegacy\V3\Util as CryptoUtil;
 
 /**
  * Class EncryptionPublicKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V3\Asymmetric
  */
 final class EncryptionPublicKey extends PublicKey
 {

--- a/src/V3/Asymmetric/EncryptionSecretKey.php
+++ b/src/V3/Asymmetric/EncryptionSecretKey.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Asymmetric;
 
-use ParagonIE\Halite\Alerts\InvalidKey;
-use ParagonIE\Halite\HiddenString;
-use ParagonIE\Halite\Util as CryptoUtil;
+use ParagonIE\HaliteLegacy\V3\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V3\HiddenString;
+use ParagonIE\HaliteLegacy\V3\Util as CryptoUtil;
 
 /**
  * Class EncryptionSecretKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V3\Asymmetric
  */
 final class EncryptionSecretKey extends SecretKey
 {

--- a/src/V3/Asymmetric/PublicKey.php
+++ b/src/V3/Asymmetric/PublicKey.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Asymmetric;
 
-use ParagonIE\Halite\HiddenString;
-use ParagonIE\Halite\Key;
+use ParagonIE\HaliteLegacy\V3\HiddenString;
+use ParagonIE\HaliteLegacy\V3\Key;
 
 /**
  * Class PublicKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V3\Asymmetric
  */
 class PublicKey extends Key
 {

--- a/src/V3/Asymmetric/SecretKey.php
+++ b/src/V3/Asymmetric/SecretKey.php
@@ -1,13 +1,13 @@
 <?php
 namespace ParagonIE\HaliteLegacy\V3\Asymmetric;
 
-use ParagonIE\Halite\HiddenString;
-use ParagonIE\Halite\Key;
-use ParagonIE\Halite\Alerts\CannotPerformOperation;
+use ParagonIE\HaliteLegacy\V3\HiddenString;
+use ParagonIE\HaliteLegacy\V3\Key;
+use ParagonIE\HaliteLegacy\V3\Alerts\CannotPerformOperation;
 
 /**
  * Class SecretKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V3\Asymmetric
  */
 class SecretKey extends Key
 {

--- a/src/V3/Asymmetric/SignaturePublicKey.php
+++ b/src/V3/Asymmetric/SignaturePublicKey.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Asymmetric;
 
-use ParagonIE\Halite\Alerts\InvalidKey;
-use ParagonIE\Halite\HiddenString;
-use ParagonIE\Halite\Util as CryptoUtil;
+use ParagonIE\HaliteLegacy\V3\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V3\HiddenString;
+use ParagonIE\HaliteLegacy\V3\Util as CryptoUtil;
 
 /**
  * Class SignaturePublicKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V3\Asymmetric
  */
 final class SignaturePublicKey extends PublicKey
 {

--- a/src/V3/Asymmetric/SignatureSecretKey.php
+++ b/src/V3/Asymmetric/SignatureSecretKey.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Asymmetric;
 
-use ParagonIE\Halite\Alerts\InvalidKey;
-use ParagonIE\Halite\HiddenString;
-use ParagonIE\Halite\Util as CryptoUtil;
+use ParagonIE\HaliteLegacy\V3\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V3\HiddenString;
+use ParagonIE\HaliteLegacy\V3\Util as CryptoUtil;
 
 /**
  * Class SignatureSecretKey
- * @package ParagonIE\Halite\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V3\Asymmetric
  */
 final class SignatureSecretKey extends SecretKey
 {

--- a/src/V3/Config.php
+++ b/src/V3/Config.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
-use ParagonIE\Halite\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V3\Alerts as CryptoException;
 
 /**
  * Class Config

--- a/src/V3/Contract/StreamInterface.php
+++ b/src/V3/Contract/StreamInterface.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Contract;
 
-use ParagonIE\Halite\Alerts\{
+use ParagonIE\HaliteLegacy\V3\Alerts\{
     CannotPerformOperation,
     FileAccessDenied
 };
@@ -17,7 +17,7 @@ use ParagonIE\Halite\Alerts\{
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\Halite\Contract
+ * @package ParagonIE\HaliteLegacy\V3\Contract
  */
 interface StreamInterface
 {

--- a/src/V3/Cookie.php
+++ b/src/V3/Cookie.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
 use ParagonIE\ConstantTime\Base64UrlSafe;
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V3\{
     Alerts\InvalidMessage,
     Symmetric\Config as SymmetricConfig,
     Symmetric\Crypto,

--- a/src/V3/EncryptionKeyPair.php
+++ b/src/V3/EncryptionKeyPair.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V3\{
     Alerts as CryptoException,
     Asymmetric\EncryptionPublicKey,
     Asymmetric\EncryptionSecretKey

--- a/src/V3/File.php
+++ b/src/V3/File.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
-use ParagonIE\Halite\Alerts\{
+use ParagonIE\HaliteLegacy\V3\Alerts\{
     CannotPerformOperation,
     FileAccessDenied,
     FileModified,
@@ -10,7 +10,7 @@ use ParagonIE\Halite\Alerts\{
     InvalidMessage,
     InvalidType
 };
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V3\{
     Asymmetric\Crypto as AsymmetricCrypto,
     Asymmetric\EncryptionPublicKey,
     Asymmetric\EncryptionSecretKey,

--- a/src/V3/Halite.php
+++ b/src/V3/Halite.php
@@ -9,7 +9,7 @@ use ParagonIE\ConstantTime\{
     Base64UrlSafe,
     Hex
 };
-use ParagonIE\Halite\Alerts\InvalidType;
+use ParagonIE\HaliteLegacy\V3\Alerts\InvalidType;
 
 /**
  * Class Halite

--- a/src/V3/Key.php
+++ b/src/V3/Key.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
-use ParagonIE\Halite\Alerts\{
+use ParagonIE\HaliteLegacy\V3\Alerts\{
     CannotCloneKey,
     CannotSerializeKey
 };

--- a/src/V3/KeyFactory.php
+++ b/src/V3/KeyFactory.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
-use ParagonIE\Halite\Alerts as CryptoException;
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V3\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V3\{
     Asymmetric\EncryptionPublicKey,
     Asymmetric\EncryptionSecretKey,
     Asymmetric\SignaturePublicKey,
@@ -67,7 +67,7 @@ final class KeyFactory
      * Generate a key pair for public key encryption
      * 
      * @param string &$secretKey
-     * @return \ParagonIE\Halite\EncryptionKeyPair
+     * @return \ParagonIE\HaliteLegacy\V3\EncryptionKeyPair
      */
     public static function generateEncryptionKeyPair(string &$secretKey = ''): EncryptionKeyPair
     {

--- a/src/V3/KeyPair.php
+++ b/src/V3/KeyPair.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
-use ParagonIE\Halite\Alerts as CryptoException;
-use ParagonIE\Halite\Asymmetric\{
+use ParagonIE\HaliteLegacy\V3\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V3\Asymmetric\{
     PublicKey,
     SecretKey
 };

--- a/src/V3/Password.php
+++ b/src/V3/Password.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
 use ParagonIE\ConstantTime\Base64UrlSafe;
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V3\{
     Alerts\InvalidMessage,
     Symmetric\Config as SymmetricConfig,
     Symmetric\Crypto,

--- a/src/V3/SignatureKeyPair.php
+++ b/src/V3/SignatureKeyPair.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V3\{
     Alerts as CryptoException,
     Asymmetric\SignaturePublicKey,
     Asymmetric\SignatureSecretKey

--- a/src/V3/Stream/MutableFile.php
+++ b/src/V3/Stream/MutableFile.php
@@ -2,9 +2,9 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Stream;
 
-use ParagonIE\Halite\Contract\StreamInterface;
-use ParagonIE\Halite\Alerts as CryptoException;
-use ParagonIE\Halite\Util as CryptoUtil;
+use ParagonIE\HaliteLegacy\V3\Contract\StreamInterface;
+use ParagonIE\HaliteLegacy\V3\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V3\Util as CryptoUtil;
 
 /**
  * Class MutableFile
@@ -16,7 +16,7 @@ use ParagonIE\Halite\Util as CryptoUtil;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\Halite\Stream
+ * @package ParagonIE\HaliteLegacy\V3\Stream
  */
 class MutableFile implements StreamInterface
 {

--- a/src/V3/Stream/ReadOnlyFile.php
+++ b/src/V3/Stream/ReadOnlyFile.php
@@ -2,10 +2,10 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Stream;
 
-use ParagonIE\Halite\Contract\StreamInterface;
-use ParagonIE\Halite\Alerts as CryptoException;
-use ParagonIE\Halite\Key;
-use ParagonIE\Halite\Util as CryptoUtil;
+use ParagonIE\HaliteLegacy\V3\Contract\StreamInterface;
+use ParagonIE\HaliteLegacy\V3\Alerts as CryptoException;
+use ParagonIE\HaliteLegacy\V3\Key;
+use ParagonIE\HaliteLegacy\V3\Util as CryptoUtil;
 
 /**
  * Class ReadOnlyFile
@@ -15,7 +15,7 @@ use ParagonIE\Halite\Util as CryptoUtil;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\Halite\Stream
+ * @package ParagonIE\HaliteLegacy\V3\Stream
  */
 class ReadOnlyFile implements StreamInterface
 {

--- a/src/V3/Structure/MerkleTree.php
+++ b/src/V3/Structure/MerkleTree.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Structure;
 
-use ParagonIE\Halite\Util;
-use ParagonIE\Halite\Alerts\InvalidDigestLength;
+use ParagonIE\HaliteLegacy\V3\Util;
+use ParagonIE\HaliteLegacy\V3\Alerts\InvalidDigestLength;
 
 /**
  * Class MerkleTree
@@ -16,7 +16,7 @@ use ParagonIE\Halite\Alerts\InvalidDigestLength;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\Halite\Structure
+ * @package ParagonIE\HaliteLegacy\V3\Structure
  */
 class MerkleTree
 {

--- a/src/V3/Structure/Node.php
+++ b/src/V3/Structure/Node.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Structure;
 
-use ParagonIE\Halite\Util;
+use ParagonIE\HaliteLegacy\V3\Util;
 
 /**
  * Class Node
@@ -12,7 +12,7 @@ use ParagonIE\Halite\Util;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\Halite\Structure
+ * @package ParagonIE\HaliteLegacy\V3\Structure
  */
 class Node
 {

--- a/src/V3/Structure/TrimmedMerkleTree.php
+++ b/src/V3/Structure/TrimmedMerkleTree.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Structure;
 
-use ParagonIE\Halite\Util;
+use ParagonIE\HaliteLegacy\V3\Util;
 
 /**
  * Class TrimmedMerkleTree
@@ -18,7 +18,7 @@ use ParagonIE\Halite\Util;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\Halite\Structure
+ * @package ParagonIE\HaliteLegacy\V3\Structure
  */
 class TrimmedMerkleTree extends MerkleTree
 {

--- a/src/V3/Symmetric/AuthenticationKey.php
+++ b/src/V3/Symmetric/AuthenticationKey.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Symmetric;
 
-use ParagonIE\Halite\Alerts\InvalidKey;
-use ParagonIE\Halite\HiddenString;
-use ParagonIE\Halite\Util as CryptoUtil;
+use ParagonIE\HaliteLegacy\V3\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V3\HiddenString;
+use ParagonIE\HaliteLegacy\V3\Util as CryptoUtil;
 
 /**
  * Class AuthenticationKey
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V3\Symmetric
  */
 final class AuthenticationKey extends SecretKey
 {

--- a/src/V3/Symmetric/Config.php
+++ b/src/V3/Symmetric/Config.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Symmetric;
 
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V3\{
     Alerts as CryptoException,
     Config as BaseConfig,
     Halite,
@@ -19,7 +19,7 @@ use ParagonIE\Halite\{
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V3\Symmetric
  */
 final class Config extends BaseConfig
 {

--- a/src/V3/Symmetric/Crypto.php
+++ b/src/V3/Symmetric/Crypto.php
@@ -2,12 +2,12 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Symmetric;
 
-use ParagonIE\Halite\Alerts\{
+use ParagonIE\HaliteLegacy\V3\Alerts\{
     InvalidKey,
     InvalidMessage,
     InvalidSignature
 };
-use ParagonIE\Halite\{
+use ParagonIE\HaliteLegacy\V3\{
     Config as BaseConfig,
     Halite,
     HiddenString,
@@ -25,7 +25,7 @@ use ParagonIE\Halite\{
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V3\Symmetric
  */
 final class Crypto
 {

--- a/src/V3/Symmetric/EncryptionKey.php
+++ b/src/V3/Symmetric/EncryptionKey.php
@@ -2,13 +2,13 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Symmetric;
 
-use ParagonIE\Halite\Alerts\InvalidKey;
-use ParagonIE\Halite\HiddenString;
-use ParagonIE\Halite\Util as CryptoUtil;
+use ParagonIE\HaliteLegacy\V3\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V3\HiddenString;
+use ParagonIE\HaliteLegacy\V3\Util as CryptoUtil;
 
 /**
  * Class EncryptionKey
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V3\Symmetric
  */
 final class EncryptionKey extends SecretKey
 {

--- a/src/V3/Symmetric/SecretKey.php
+++ b/src/V3/Symmetric/SecretKey.php
@@ -2,11 +2,11 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3\Symmetric;
 
-use ParagonIE\Halite\Key;
+use ParagonIE\HaliteLegacy\V3\Key;
 
 /**
  * Class SecretKey
- * @package ParagonIE\Halite\Symmetric
+ * @package ParagonIE\HaliteLegacy\V3\Symmetric
  */
 class SecretKey extends Key
 {

--- a/src/V3/Util.php
+++ b/src/V3/Util.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V3;
 
-use ParagonIE\Halite\Alerts\{
+use ParagonIE\HaliteLegacy\V3\Alerts\{
     CannotPerformOperation,
     InvalidDigestLength,
     InvalidType


### PR DESCRIPTION
Some `use` statements and bare fqcns did not point at the correct legacy version of the class (e.g., in `V1` code, `use ParagonIE\Halite\Alerts as CryptoException;` should be `use ParagonIE\HaliteLegacy\V1\Alerts as CryptoException;`).