### PR TITLE
add php8 support and update dependency to latest Halite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
   "description": "Legacy implementations of Halite (can be loaded alongside Halite to facilitate migrations)",
   "type": "library",
   "require": {
-    "php": "^7",
-    "paragonie/halite": "^4.5",
+    "php": "^7|^8",
+    "paragonie/halite": "^5.1",
     "paragonie/sodium_compat": "^1.9"
   },
   "require-dev": {


### PR DESCRIPTION
The changes has been tested with sideloading halite 5.1 as shown below

```php
<?php

require_once 'vendor/autoload.php';

use ParagonIE\HaliteLegacy\V1\Symmetric\Crypto as LegacyCrypto;
use \ParagonIE\HaliteLegacy\V1\KeyFactory as LegacyKeyFactory;

$Key = LegacyKeyFactory::generateEncryptionKey();


$v1Enc = LegacyCrypto::encrypt('test', $Key);
$plain = LegacyCrypto::decrypt($v1Enc, $Key);

$sameKeyNewWay = new \ParagonIE\Halite\Symmetric\EncryptionKey(new \ParagonIE\HiddenString\HiddenString($oldKey->getRawKeyMaterial()));
$enc = \ParagonIE\Halite\Symmetric\Crypto::encrypt(new \ParagonIE\HiddenString\HiddenString($plain), $sameKeyNewWay);

var_dump($enc);
```