### PR TITLE
Fix V4 namespaces in all classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ You can use it like so:
 ```php
 <?php
 use ParagonIE\HaliteLegacy\VersionHelper;
-use ParagonIE\Halite\Halite\Symmetric\Crypto as SymmetricLatest;
-use ParagonIE\Halite\HaliteLegacy\V4\Symmetric\Crypto as SymmetricV4;
+use ParagonIE\Halite\Symmetric\Crypto as SymmetricLatest;
+use ParagonIE\HaliteLegacy\V4\Symmetric\Crypto as SymmetricV4;
 
 // Version will be an integer, or it will throw
 $inferredVersion = VersionHelper::inferVersionFromCiphertext($ciphertext);

--- a/src/V4/Alerts/CannotCloneKey.php
+++ b/src/V4/Alerts/CannotCloneKey.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class CannotCloneKey
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * CannotCloneKey

--- a/src/V4/Alerts/CannotPerformOperation.php
+++ b/src/V4/Alerts/CannotPerformOperation.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class CannotPerformOperation
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * CannotPerformOperation

--- a/src/V4/Alerts/CannotSerializeKey.php
+++ b/src/V4/Alerts/CannotSerializeKey.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class CannotSerializeKey
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * CannotSerializeKey

--- a/src/V4/Alerts/ConfigDirectiveNotFound.php
+++ b/src/V4/Alerts/ConfigDirectiveNotFound.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class ConfigDirectiveNotFound
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * ConfigDirectiveNotFound

--- a/src/V4/Alerts/FileAccessDenied.php
+++ b/src/V4/Alerts/FileAccessDenied.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class FileAccessDenied
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * FileAccessDenied

--- a/src/V4/Alerts/FileError.php
+++ b/src/V4/Alerts/FileError.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class FileAccessDenied
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * FileError

--- a/src/V4/Alerts/FileModified.php
+++ b/src/V4/Alerts/FileModified.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class FileModified
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * FileModified

--- a/src/V4/Alerts/HaliteAlert.php
+++ b/src/V4/Alerts/HaliteAlert.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class HaliteAlert
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * HaliteAlert

--- a/src/V4/Alerts/HaliteAlertInterface.php
+++ b/src/V4/Alerts/HaliteAlertInterface.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Interface HaliteAlertInterface
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * HaliteAlertInterface

--- a/src/V4/Alerts/InvalidDigestLength.php
+++ b/src/V4/Alerts/InvalidDigestLength.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class InvalidDigestLength
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * InvalidDigestLength

--- a/src/V4/Alerts/InvalidFlags.php
+++ b/src/V4/Alerts/InvalidFlags.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class InvalidFlags
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * InvalidFlags

--- a/src/V4/Alerts/InvalidKey.php
+++ b/src/V4/Alerts/InvalidKey.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class InvalidKey
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * InvalidKey

--- a/src/V4/Alerts/InvalidMessage.php
+++ b/src/V4/Alerts/InvalidMessage.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class InvalidMessage
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * InvalidMessage

--- a/src/V4/Alerts/InvalidSalt.php
+++ b/src/V4/Alerts/InvalidSalt.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class InvalidSalt
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * InvalidSalt

--- a/src/V4/Alerts/InvalidSignature.php
+++ b/src/V4/Alerts/InvalidSignature.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class InvalidSignature
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * InvalidSignature

--- a/src/V4/Alerts/InvalidType.php
+++ b/src/V4/Alerts/InvalidType.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 /**
  * Class InvalidType
  *
- * @package ParagonIE\HaliteLegacy\Alerts
+ * @package ParagonIE\HaliteLegacy\V4\Alerts
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-namespace ParagonIE\HaliteLegacy\Alerts;
+namespace ParagonIE\HaliteLegacy\V4\Alerts;
 
 /**
  * InvalidType

--- a/src/V4/Asymmetric/Crypto.php
+++ b/src/V4/Asymmetric/Crypto.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Asymmetric;
+namespace ParagonIE\HaliteLegacy\V4\Asymmetric;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     InvalidDigestLength,
     InvalidKey,
@@ -11,7 +11,7 @@ use ParagonIE\HaliteLegacy\Alerts\{
     InvalidSignature,
     InvalidType
 };
-use ParagonIE\HaliteLegacy\{
+use ParagonIE\HaliteLegacy\V4\{
     Halite,
     Key,
     Symmetric\Crypto as SymmetricCrypto,
@@ -30,7 +30,7 @@ use ParagonIE\HiddenString\HiddenString;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\HaliteLegacy\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V4\Asymmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Asymmetric/EncryptionPublicKey.php
+++ b/src/V4/Asymmetric/EncryptionPublicKey.php
@@ -1,14 +1,14 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Asymmetric;
+namespace ParagonIE\HaliteLegacy\V4\Asymmetric;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidKey;
 use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class EncryptionPublicKey
- * @package ParagonIE\HaliteLegacy\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V4\Asymmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Asymmetric/EncryptionSecretKey.php
+++ b/src/V4/Asymmetric/EncryptionSecretKey.php
@@ -1,14 +1,14 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Asymmetric;
+namespace ParagonIE\HaliteLegacy\V4\Asymmetric;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidKey;
 use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class EncryptionSecretKey
- * @package ParagonIE\HaliteLegacy\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V4\Asymmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Asymmetric/PublicKey.php
+++ b/src/V4/Asymmetric/PublicKey.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Asymmetric;
+namespace ParagonIE\HaliteLegacy\V4\Asymmetric;
 
-use ParagonIE\HaliteLegacy\Key;
+use ParagonIE\HaliteLegacy\V4\Key;
 use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class PublicKey
- * @package ParagonIE\HaliteLegacy\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V4\Asymmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Asymmetric/SecretKey.php
+++ b/src/V4/Asymmetric/SecretKey.php
@@ -1,13 +1,13 @@
 <?php
-namespace ParagonIE\HaliteLegacy\Asymmetric;
+namespace ParagonIE\HaliteLegacy\V4\Asymmetric;
 
-use ParagonIE\HaliteLegacy\Alerts\CannotPerformOperation;
-use ParagonIE\HaliteLegacy\Key;
+use ParagonIE\HaliteLegacy\V4\Alerts\CannotPerformOperation;
+use ParagonIE\HaliteLegacy\V4\Key;
 use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class SecretKey
- * @package ParagonIE\HaliteLegacy\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V4\Asymmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Asymmetric/SignaturePublicKey.php
+++ b/src/V4/Asymmetric/SignaturePublicKey.php
@@ -1,14 +1,14 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Asymmetric;
+namespace ParagonIE\HaliteLegacy\V4\Asymmetric;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidKey;
 use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class SignaturePublicKey
- * @package ParagonIE\HaliteLegacy\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V4\Asymmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Asymmetric/SignatureSecretKey.php
+++ b/src/V4/Asymmetric/SignatureSecretKey.php
@@ -1,14 +1,14 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Asymmetric;
+namespace ParagonIE\HaliteLegacy\V4\Asymmetric;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidKey;
 use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class SignatureSecretKey
- * @package ParagonIE\HaliteLegacy\Asymmetric
+ * @package ParagonIE\HaliteLegacy\V4\Asymmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Config.php
+++ b/src/V4/Config.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V4;
 
-use ParagonIE\HaliteLegacy\Alerts\ConfigDirectiveNotFound;
+use ParagonIE\HaliteLegacy\V4\Alerts\ConfigDirectiveNotFound;
 
 /**
  * Class Config

--- a/src/V4/Contract/StreamInterface.php
+++ b/src/V4/Contract/StreamInterface.php
@@ -1,8 +1,8 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Contract;
+namespace ParagonIE\HaliteLegacy\V4\Contract;
 
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     FileAccessDenied
 };
@@ -17,7 +17,7 @@ use ParagonIE\HaliteLegacy\Alerts\{
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\HaliteLegacy\Contract
+ * @package ParagonIE\HaliteLegacy\V4\Contract
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Cookie.php
+++ b/src/V4/Cookie.php
@@ -7,14 +7,14 @@ use ParagonIE\ConstantTime\{
     Binary,
     Hex
 };
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     InvalidDigestLength,
     InvalidMessage,
     InvalidSignature,
     InvalidType
 };
-use ParagonIE\HaliteLegacy\Symmetric\{
+use ParagonIE\HaliteLegacy\V4\Symmetric\{
     Config as SymmetricConfig,
     Crypto,
     EncryptionKey

--- a/src/V4/EncryptionKeyPair.php
+++ b/src/V4/EncryptionKeyPair.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V4;
 
-use ParagonIE\HaliteLegacy\Alerts\InvalidKey;
-use ParagonIE\HaliteLegacy\Asymmetric\{
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V4\Asymmetric\{
     EncryptionPublicKey,
     EncryptionSecretKey
 };

--- a/src/V4/File.php
+++ b/src/V4/File.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V4;
 
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     FileAccessDenied,
     FileError,
@@ -13,7 +13,7 @@ use ParagonIE\HaliteLegacy\Alerts\{
     InvalidSignature,
     InvalidType
 };
-use ParagonIE\HaliteLegacy\{
+use ParagonIE\HaliteLegacy\V4\{
     Asymmetric\Crypto as AsymmetricCrypto,
     Asymmetric\EncryptionPublicKey,
     Asymmetric\EncryptionSecretKey,

--- a/src/V4/Halite.php
+++ b/src/V4/Halite.php
@@ -9,7 +9,7 @@ use ParagonIE\ConstantTime\{
     Base64UrlSafe,
     Hex
 };
-use ParagonIE\HaliteLegacy\Alerts\InvalidType;
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidType;
 
 /**
  * Class Halite

--- a/src/V4/Key.php
+++ b/src/V4/Key.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V4;
 
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotCloneKey,
     CannotSerializeKey
 };

--- a/src/V4/KeyFactory.php
+++ b/src/V4/KeyFactory.php
@@ -6,13 +6,13 @@ use ParagonIE\ConstantTime\{
     Binary,
     Hex
 };
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     InvalidKey,
     InvalidSalt,
     InvalidType
 };
-use ParagonIE\HaliteLegacy\{
+use ParagonIE\HaliteLegacy\V4\{
     Asymmetric\EncryptionPublicKey,
     Asymmetric\EncryptionSecretKey,
     Asymmetric\SignaturePublicKey,

--- a/src/V4/KeyPair.php
+++ b/src/V4/KeyPair.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V4;
 
-use ParagonIE\HaliteLegacy\Asymmetric\{
+use ParagonIE\HaliteLegacy\V4\Asymmetric\{
     PublicKey,
     SecretKey
 };

--- a/src/V4/Password.php
+++ b/src/V4/Password.php
@@ -7,13 +7,13 @@ use ParagonIE\ConstantTime\{
     Binary,
     Hex
 };
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     InvalidDigestLength,
     InvalidMessage,
     InvalidType
 };
-use ParagonIE\HaliteLegacy\Symmetric\{
+use ParagonIE\HaliteLegacy\V4\Symmetric\{
     Config as SymmetricConfig,
     Crypto,
     EncryptionKey

--- a/src/V4/SignatureKeyPair.php
+++ b/src/V4/SignatureKeyPair.php
@@ -2,8 +2,8 @@
 declare(strict_types=1);
 namespace ParagonIE\HaliteLegacy\V4;
 
-use ParagonIE\HaliteLegacy\Alerts\InvalidKey;
-use ParagonIE\HaliteLegacy\Asymmetric\{
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V4\Asymmetric\{
     SignaturePublicKey,
     SignatureSecretKey
 };

--- a/src/V4/Stream/MutableFile.php
+++ b/src/V4/Stream/MutableFile.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Stream;
+namespace ParagonIE\HaliteLegacy\V4\Stream;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Contract\StreamInterface;
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Contract\StreamInterface;
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     FileAccessDenied,
     InvalidType
@@ -20,7 +20,7 @@ use ParagonIE\HaliteLegacy\Alerts\{
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\HaliteLegacy\Stream
+ * @package ParagonIE\HaliteLegacy\V4\Stream
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Stream/ReadOnlyFile.php
+++ b/src/V4/Stream/ReadOnlyFile.php
@@ -1,17 +1,17 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Stream;
+namespace ParagonIE\HaliteLegacy\V4\Stream;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Contract\StreamInterface;
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Contract\StreamInterface;
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     FileAccessDenied,
     FileError,
     FileModified,
     InvalidType,
 };
-use ParagonIE\HaliteLegacy\Key;
+use ParagonIE\HaliteLegacy\V4\Key;
 
 /**
  * Class ReadOnlyFile
@@ -21,7 +21,7 @@ use ParagonIE\HaliteLegacy\Key;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\HaliteLegacy\Stream
+ * @package ParagonIE\HaliteLegacy\V4\Stream
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Stream/WeakReadOnlyFile.php
+++ b/src/V4/Stream/WeakReadOnlyFile.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Stream;
+namespace ParagonIE\HaliteLegacy\V4\Stream;
 
 /**
  * Class WeakReadOnlyFile
  *
  * Like ReadOnlyFile, but with weaker guarantees
  *
- * @package ParagonIE\HaliteLegacy\Stream
+ * @package ParagonIE\HaliteLegacy\V4\Stream
  */
 class WeakReadOnlyFile extends ReadOnlyFile
 {

--- a/src/V4/Structure/MerkleTree.php
+++ b/src/V4/Structure/MerkleTree.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Structure;
+namespace ParagonIE\HaliteLegacy\V4\Structure;
 
 use ParagonIE\ConstantTime\Hex;
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     InvalidDigestLength
 };
-use ParagonIE\HaliteLegacy\Util;
+use ParagonIE\HaliteLegacy\V4\Util;
 
 /**
  * Class MerkleTree
@@ -20,7 +20,7 @@ use ParagonIE\HaliteLegacy\Util;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\HaliteLegacy\Structure
+ * @package ParagonIE\HaliteLegacy\V4\Structure
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Structure/Node.php
+++ b/src/V4/Structure/Node.php
@@ -1,9 +1,9 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Structure;
+namespace ParagonIE\HaliteLegacy\V4\Structure;
 
-use ParagonIE\HaliteLegacy\Alerts\CannotPerformOperation;
-use ParagonIE\HaliteLegacy\Util;
+use ParagonIE\HaliteLegacy\V4\Alerts\CannotPerformOperation;
+use ParagonIE\HaliteLegacy\V4\Util;
 
 /**
  * Class Node
@@ -13,7 +13,7 @@ use ParagonIE\HaliteLegacy\Util;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\HaliteLegacy\Structure
+ * @package ParagonIE\HaliteLegacy\V4\Structure
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Structure/TrimmedMerkleTree.php
+++ b/src/V4/Structure/TrimmedMerkleTree.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Structure;
+namespace ParagonIE\HaliteLegacy\V4\Structure;
 
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     InvalidDigestLength
 };
-use ParagonIE\HaliteLegacy\Util;
+use ParagonIE\HaliteLegacy\V4\Util;
 
 /**
  * Class TrimmedMerkleTree
@@ -22,7 +22,7 @@ use ParagonIE\HaliteLegacy\Util;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\HaliteLegacy\Structure
+ * @package ParagonIE\HaliteLegacy\V4\Structure
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Symmetric/AuthenticationKey.php
+++ b/src/V4/Symmetric/AuthenticationKey.php
@@ -1,14 +1,14 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Symmetric;
+namespace ParagonIE\HaliteLegacy\V4\Symmetric;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidKey;
 use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class AuthenticationKey
- * @package ParagonIE\HaliteLegacy\Symmetric
+ * @package ParagonIE\HaliteLegacy\V4\Symmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Symmetric/Config.php
+++ b/src/V4/Symmetric/Config.php
@@ -1,10 +1,10 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Symmetric;
+namespace ParagonIE\HaliteLegacy\V4\Symmetric;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Alerts\InvalidMessage;
-use ParagonIE\HaliteLegacy\{
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidMessage;
+use ParagonIE\HaliteLegacy\V4\{
     Config as BaseConfig,
     Halite
 };
@@ -19,7 +19,7 @@ use ParagonIE\HaliteLegacy\{
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\HaliteLegacy\Symmetric
+ * @package ParagonIE\HaliteLegacy\V4\Symmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Symmetric/Crypto.php
+++ b/src/V4/Symmetric/Crypto.php
@@ -1,16 +1,16 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Symmetric;
+namespace ParagonIE\HaliteLegacy\V4\Symmetric;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     InvalidDigestLength,
     InvalidMessage,
     InvalidSignature,
     InvalidType
 };
-use ParagonIE\HaliteLegacy\{
+use ParagonIE\HaliteLegacy\V4\{
     Config as BaseConfig,
     Halite,
     Symmetric\Config as SymmetricConfig,
@@ -28,7 +28,7 @@ use ParagonIE\HiddenString\HiddenString;
  *
  * @ref http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration
  *
- * @package ParagonIE\HaliteLegacy\Symmetric
+ * @package ParagonIE\HaliteLegacy\V4\Symmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Symmetric/EncryptionKey.php
+++ b/src/V4/Symmetric/EncryptionKey.php
@@ -1,14 +1,14 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Symmetric;
+namespace ParagonIE\HaliteLegacy\V4\Symmetric;
 
 use ParagonIE\ConstantTime\Binary;
-use ParagonIE\HaliteLegacy\Alerts\InvalidKey;
+use ParagonIE\HaliteLegacy\V4\Alerts\InvalidKey;
 use ParagonIE\HiddenString\HiddenString;
 
 /**
  * Class EncryptionKey
- * @package ParagonIE\HaliteLegacy\Symmetric
+ * @package ParagonIE\HaliteLegacy\V4\Symmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Symmetric/SecretKey.php
+++ b/src/V4/Symmetric/SecretKey.php
@@ -1,12 +1,12 @@
 <?php
 declare(strict_types=1);
-namespace ParagonIE\HaliteLegacy\Symmetric;
+namespace ParagonIE\HaliteLegacy\V4\Symmetric;
 
-use ParagonIE\HaliteLegacy\Key;
+use ParagonIE\HaliteLegacy\V4\Key;
 
 /**
  * Class SecretKey
- * @package ParagonIE\HaliteLegacy\Symmetric
+ * @package ParagonIE\HaliteLegacy\V4\Symmetric
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/V4/Util.php
+++ b/src/V4/Util.php
@@ -6,7 +6,7 @@ use ParagonIE\ConstantTime\{
     Binary,
     Hex
 };
-use ParagonIE\HaliteLegacy\Alerts\{
+use ParagonIE\HaliteLegacy\V4\Alerts\{
     CannotPerformOperation,
     InvalidDigestLength,
     InvalidType


### PR DESCRIPTION
Hey 👋 

Following instructions on [how to perform a migration](https://github.com/jgrossi/halite-legacy?tab=readme-ov-file#how-to-perform-a-migration) I found out that the namespace for V4 classes in `halite-legacy` 0.2.0 are wrong, and Composer can't autoload them.

This PR updates README file along with the classes under V4 folder, so they have proper namespaces and can be autoloaded by Composer.

Thank you 🙏 